### PR TITLE
Problem: our types were too loose

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,0 +1,25 @@
+package gomq
+
+import "github.com/zeromq/gomq/zmtp"
+
+// ClientSocket is a ZMQ_CLIENT socket type.
+// See: http://rfc.zeromq.org/spec:41
+type ClientSocket struct {
+	*Socket
+}
+
+// NewClient accepts a zmtp.SecurityMechanism and returns
+// a ClientSocket as a gomq.Client interface.
+func NewClient(mechanism zmtp.SecurityMechanism) Client {
+	return &ClientSocket{
+		Socket: NewSocket(false, zmtp.ClientSocketType, mechanism),
+	}
+}
+
+// Connect accepts a zeromq endpoint and connects the
+// client socket to it. Currently the only transport
+// supported is TCP. The endpoint string should be
+// in the format "tcp://<address>:<port>".
+func (c *ClientSocket) Connect(endpoint string) error {
+	return ConnectClient(c, endpoint)
+}

--- a/gomq.go
+++ b/gomq.go
@@ -1,0 +1,113 @@
+package gomq
+
+import (
+	"net"
+	"strings"
+	"time"
+
+	"github.com/zeromq/gomq/zmtp"
+)
+
+var (
+	defaultRetry = 250 * time.Millisecond
+)
+
+// Connection is a gomq connection. It holds
+// both the net.Conn transport as well as the
+// zmtp connection information.
+type Connection struct {
+	net  net.Conn
+	zmtp *zmtp.Connection
+}
+
+// ZeroMQSocket is the base gomq interface.
+type ZeroMQSocket interface {
+	Recv() ([]byte, error)
+	Send([]byte) error
+	RetryInterval() time.Duration
+	SocketType() zmtp.SocketType
+	SecurityMechanism() zmtp.SecurityMechanism
+	AddConnection(conn *Connection)
+	RecvChannel() chan *zmtp.Message
+	Close()
+}
+
+// Client is a gomq interface used for client sockets.
+// It implements the Socket interface along with a
+// Connect method for connecting to endpoints.
+type Client interface {
+	ZeroMQSocket
+	Connect(endpoint string) error
+}
+
+// ConnectClient accepts a Client interface and an endpoint
+// in the format <proto>://<address>:<port>. It then attempts
+// to connect to the endpoint and perform a ZMTP handshake.
+func ConnectClient(c Client, endpoint string) error {
+	parts := strings.Split(endpoint, "://")
+
+Connect:
+	netConn, err := net.Dial(parts[0], parts[1])
+	if err != nil {
+		time.Sleep(c.RetryInterval())
+		goto Connect
+	}
+
+	zmtpConn := zmtp.NewConnection(netConn)
+	_, err = zmtpConn.Prepare(c.SecurityMechanism(), c.SocketType(), false, nil)
+	if err != nil {
+		return err
+	}
+
+	conn := &Connection{
+		net:  netConn,
+		zmtp: zmtpConn,
+	}
+
+	c.AddConnection(conn)
+	zmtpConn.Recv(c.RecvChannel())
+	return nil
+}
+
+// Server is a gomq interface used for server sockets.
+// It implements the Socket interface along with a
+// Bind method for binding to endpoints.
+type Server interface {
+	ZeroMQSocket
+	Bind(endpoint string) (net.Addr, error)
+}
+
+// BindServer accepts a Server interface and an endpoint
+// in the format <proto>://<address>:<port>. It then attempts
+// to bind to the endpoint. TODO: change this to starting
+// a listener on the endpoint that performs handshakes
+// with any client that connects
+func BindServer(s Server, endpoint string) (net.Addr, error) {
+	var addr net.Addr
+	parts := strings.Split(endpoint, "://")
+
+	ln, err := net.Listen(parts[0], parts[1])
+	if err != nil {
+		return addr, err
+	}
+
+	netConn, err := ln.Accept()
+	if err != nil {
+		return addr, err
+	}
+
+	zmtpConn := zmtp.NewConnection(netConn)
+	_, err = zmtpConn.Prepare(s.SecurityMechanism(), s.SocketType(), true, nil)
+	if err != nil {
+		return netConn.LocalAddr(), err
+	}
+
+	conn := &Connection{
+		net:  netConn,
+		zmtp: zmtpConn,
+	}
+
+	s.AddConnection(conn)
+	zmtpConn.Recv(s.RecvChannel())
+	return netConn.LocalAddr(), nil
+}

--- a/server.go
+++ b/server.go
@@ -1,0 +1,29 @@
+package gomq
+
+import (
+	"net"
+
+	"github.com/zeromq/gomq/zmtp"
+)
+
+// ServerSocket is a ZMQ_SERVER socket type.
+// See: http://rfc.zeromq.org/spec:41
+type ServerSocket struct {
+	*Socket
+}
+
+// NewServer accepts a zmtp.SecurityMechanism and returns
+// a ServerSocket as a gomq.Server interface.
+func NewServer(mechanism zmtp.SecurityMechanism) Server {
+	return &ServerSocket{
+		Socket: NewSocket(true, zmtp.ServerSocketType, mechanism),
+	}
+}
+
+// Bind accepts a zeromq endpoint and binds the
+// server socket to it. Currently the only transport
+// supported is TCP. The endpoint string should be
+// in the format "tcp://<address>:<port>".
+func (s *ServerSocket) Bind(endpoint string) (net.Addr, error) {
+	return BindServer(s, endpoint)
+}

--- a/socket.go
+++ b/socket.go
@@ -1,178 +1,114 @@
 package gomq
 
 import (
-	"errors"
-	"net"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/zeromq/gomq/zmtp"
 )
 
-var (
-	// ErrInvalidSockAction is returned when an action is performed
-	// on a socket type that does not support the action
-	ErrInvalidSockAction = errors.New("action not valid on this socket")
-
-	defaultRetry = 250 * time.Millisecond
-)
-
-// Connection holds a connection to a ZeroMQ socket.
-type Connection struct {
-	netconn  net.Conn
-	zmtpconn *zmtp.Connection
-}
-
-// Socket represents a ZeroMQ socket. Sockets may have multiple connections.
-type Socket interface {
-	Recv() ([]byte, error)
-	Send([]byte) error
-	Connect(endpoint string) error
-	Bind(endpoint string) (net.Addr, error)
-	Close()
-}
-
-type socket struct {
+// Socket is the base GoMQ socket type. It should probably
+// not be used directly. Specifically typed sockets such
+// as ClientSocket, ServerSocket, etc embed this type.
+type Socket struct {
 	sockType      zmtp.SocketType
 	asServer      bool
 	conns         map[string]*Connection
-	clients       []string
+	ids           []string
 	retryInterval time.Duration
 	lock          *sync.RWMutex
 	mechanism     zmtp.SecurityMechanism
-	messageChan   chan *zmtp.Message
+	recvChannel   chan *zmtp.Message
 }
 
-func newSocket(sockType zmtp.SocketType, asServer bool, mechanism zmtp.SecurityMechanism) Socket {
-	return &socket{
+// NewSocket accepts an asServer boolean, zmtp.SocketType and a zmtp.SecurityMechanism
+// and returns a *Socket.
+func NewSocket(asServer bool, sockType zmtp.SocketType, mechanism zmtp.SecurityMechanism) *Socket {
+	return &Socket{
 		lock:          &sync.RWMutex{},
 		asServer:      asServer,
 		sockType:      sockType,
 		retryInterval: defaultRetry,
 		mechanism:     mechanism,
 		conns:         make(map[string]*Connection),
-		clients:       make([]string, 0),
-		messageChan:   make(chan *zmtp.Message),
+		ids:           make([]string, 0),
+		recvChannel:   make(chan *zmtp.Message),
 	}
 }
 
-// Connect connects to an endpoint.
-// TODO: this call should be non blocking
-func (s *socket) Connect(endpoint string) error {
-	if s.asServer {
-		return ErrInvalidSockAction
-	}
-
-	parts := strings.Split(endpoint, "://")
-
-Connect:
-	netconn, err := net.Dial(parts[0], parts[1])
-	if err != nil {
-		time.Sleep(s.retryInterval)
-		goto Connect
-	}
-
-	zmtpconn := zmtp.NewConnection(netconn)
-	_, err = zmtpconn.Prepare(s.mechanism, s.sockType, s.asServer, nil)
-	if err != nil {
-		return err
-	}
-
-	conn := &Connection{
-		netconn:  netconn,
-		zmtpconn: zmtpconn,
-	}
-
-	s.addConn(conn)
-	zmtpconn.Recv(s.messageChan)
-	return nil
-}
-
-// Bind binds to an endpoint.
-func (s *socket) Bind(endpoint string) (net.Addr, error) {
-	var addr net.Addr
-
-	if !s.asServer {
-		return addr, ErrInvalidSockAction
-	}
-
-	parts := strings.Split(endpoint, "://")
-
-	ln, err := net.Listen(parts[0], parts[1])
-	if err != nil {
-		return addr, err
-	}
-
-	netconn, err := ln.Accept()
-	if err != nil {
-		return addr, err
-	}
-
-	zmtpconn := zmtp.NewConnection(netconn)
-	_, err = zmtpconn.Prepare(s.mechanism, s.sockType, s.asServer, nil)
-	if err != nil {
-		return netconn.LocalAddr(), err
-	}
-
-	conn := &Connection{
-		netconn:  netconn,
-		zmtpconn: zmtpconn,
-	}
-
-	s.addConn(conn)
-	zmtpconn.Recv(s.messageChan)
-	return netconn.LocalAddr(), nil
-}
-
-func (s *socket) addConn(conn *Connection) {
+// AddConnection adds a gomq.Connection to the socket.
+// It is goroutine safe.
+func (s *Socket) AddConnection(conn *Connection) {
 	s.lock.Lock()
-	uuid, _ := newUUID()
+	uuid, err := newUUID()
+	if err != nil {
+		panic(err)
+	}
+
 	s.conns[uuid] = conn
-	s.clients = append(s.clients, uuid)
+	s.ids = append(s.ids, uuid)
 	s.lock.Unlock()
 }
 
-func (s *socket) removeConn(uuid string) {
+// RemoveConnection accepts the uuid of a connection
+// and removes that gomq.Connection from the socket
+// if it exists. FIXME will bomb if uuid does not
+// exist in map
+func (s *Socket) RemoveConnection(uuid string) {
 	s.lock.Lock()
-	for k, v := range s.clients {
+	for k, v := range s.ids {
 		if v == uuid {
-			s.clients = append(s.clients[:k], s.clients[k+1:]...)
+			s.ids = append(s.ids[:k], s.ids[k+1:]...)
 		}
 	}
+	s.conns[uuid].net.Close()
 	delete(s.conns, uuid)
 	s.lock.Unlock()
 }
 
-// Close closes all underlying connections in a socket.
-func (s *socket) Close() {
+// RetryInterval returns the retry interval used
+// for asyncronous bind / connect.
+func (s *Socket) RetryInterval() time.Duration {
+	return s.retryInterval
+}
+
+// SocketType returns the Socket's zmtp.SocketType.
+func (s *Socket) SocketType() zmtp.SocketType {
+	return s.sockType
+}
+
+// SecurityMechanism returns the Socket's zmtp.SecurityMechanism.
+func (s *Socket) SecurityMechanism() zmtp.SecurityMechanism {
+	return s.mechanism
+}
+
+// RecvChannel returns the Socket's receive channel used
+// for receiving messages.
+func (s *Socket) RecvChannel() chan *zmtp.Message {
+	return s.recvChannel
+}
+
+// Close closes all underlying transport connections
+// for the socket.
+func (s *Socket) Close() {
 	s.lock.Lock()
-	for k, v := range s.clients {
-		s.conns[v].netconn.Close()
-		s.clients = append(s.clients[:k], s.clients[k+1:]...)
+	for k, v := range s.ids {
+		s.conns[v].net.Close()
+		s.ids = append(s.ids[:k], s.ids[k+1:]...)
 	}
 	s.lock.Unlock()
 }
 
-// NewClient creates a new ZMQ_CLIENT socket.
-func NewClient(mechanism zmtp.SecurityMechanism) Socket {
-	return newSocket(zmtp.ClientSocketType, false, mechanism)
-}
-
-// NewServer creates a new ZMQ_SERVER socket.
-func NewServer(mechanism zmtp.SecurityMechanism) Socket {
-	return newSocket(zmtp.ServerSocketType, true, mechanism)
-}
-
-// Recv receives the next message from the socket.
-func (s *socket) Recv() ([]byte, error) {
-	msg := <-s.messageChan
+// Recv receives a message from the Socket's
+// message channel and returns it.
+func (s *Socket) Recv() ([]byte, error) {
+	msg := <-s.recvChannel
 	if msg.MessageType == zmtp.CommandMessage {
 	}
 	return msg.Body, msg.Err
 }
 
-// Send sends a message.
-func (s *socket) Send(b []byte) error {
-	return s.conns[s.clients[0]].zmtpconn.SendFrame(b)
+// Send sends a message. FIXME should use a channel.
+func (s *Socket) Send(b []byte) error {
+	return s.conns[s.ids[0]].zmtp.SendFrame(b)
 }

--- a/uuid.go
+++ b/uuid.go
@@ -8,13 +8,13 @@ import (
 
 func newUUID() (string, error) {
 	uuid := make([]byte, 16)
+
 	n, err := io.ReadFull(rand.Reader, uuid)
 	if n != len(uuid) || err != nil {
 		return "", err
 	}
-	// variant bits; see section 4.1.1
+
 	uuid[8] = uuid[8]&^0xc0 | 0x80
-	// version 4 (pseudo-random); see section 4.1.3
 	uuid[6] = uuid[6]&^0xf0 | 0x40
 	return fmt.Sprintf("%x-%x-%x-%x-%x", uuid[0:4], uuid[4:6], uuid[6:8], uuid[8:10], uuid[10:]), nil
 }


### PR DESCRIPTION
Solution: rework our socket types.  This PR:

* Adds a base ZeroMQSocket interface, along with a Client interface for sockets that act as clients (e.g. connect to things) and a Server interface for sockets that act as servers (e.g., bind).
* Adds a ConnectClient function that accepts Client interfaces + an endpoint and attempts to connect the Client to the endpoint
* Adds a BindServer function that accepts Bind interfaces and binds them to an endpoint
* Adds a ClientSocket type that is a ZMQ_CLIENT socket implementing the Client interface
* Adds a ServerSocket type that is a ZMQ_SERVER socket implementing the Server interface

There is still a lot of work to be done to support multiple connections between clients and servers but this lays the groundwork for a more sane type system to build upon.
