### PR TITLE
Add gomq.NewConnection()

### DIFF
--- a/gomq.go
+++ b/gomq.go
@@ -20,6 +20,16 @@ type Connection struct {
 	zmtp *zmtp.Connection
 }
 
+// NewConnection accepts a net.Conn, a *zmtp.Connection
+// and returns a *gomq.Connection.
+func NewConnection(netConn net.Conn, zmtpConn *zmtp.Connection) *Connection {
+	conn := &Connection{
+		net:  netConn,
+		zmtp: zmtpConn,
+	}
+	return conn
+}
+
 // ZeroMQSocket is the base gomq interface.
 type ZeroMQSocket interface {
 	Recv() ([]byte, error)


### PR DESCRIPTION
Hi, [boomer](https://github.com/myzhan/boomer) is using zeromq for master-slave communication. Becase it's not so easy to setup goczmq, I'm planning to add support for gomq.

Sadly, gomq implemented PullSocket as a Client, and PushSocket as a server, and boomer needs to use PushSocket as a Client without binding on any port. So I have to use gomq.Socket directly like [this](https://github.com/myzhan/boomer/blob/ea3b608aee65d3550b311cde2c17339ce067d689/client_gomq.go#L25).