### PR TITLE
zmtp: improve perfs of Connection.read{,Multipart}

### DIFF
--- a/zmtp/conn.go
+++ b/zmtp/conn.go
@@ -113,7 +113,7 @@ func (c *Connection) sendGreeting(asServer bool) error {
 	}
 	toNullPaddedString(string(c.securityMechanism.Type()), greeting.Mechanism[:])
 
-	if err := binary.Write(c.rw, byteOrder, &greeting); err != nil {
+	if err := greeting.marshal(c.rw); err != nil {
 		return err
 	}
 
@@ -123,7 +123,7 @@ func (c *Connection) sendGreeting(asServer bool) error {
 func (c *Connection) recvGreeting(asServer bool) error {
 	var greeting greeting
 
-	if err := binary.Read(c.rw, byteOrder, &greeting); err != nil {
+	if err := greeting.unmarshal(c.rw); err != nil {
 		return fmt.Errorf("Error while reading: %v", err)
 	}
 

--- a/zmtp/conn.go
+++ b/zmtp/conn.go
@@ -2,7 +2,6 @@ package zmtp
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -233,10 +232,7 @@ func (c *Connection) recvMetadata() (map[string]string, error) {
 		i += keyLength
 
 		// Value length
-		var rawValueLength uint32
-		if err := binary.Read(bytes.NewBuffer(command.Body[i:i+4]), byteOrder, &rawValueLength); err != nil {
-			return nil, err
-		}
+		rawValueLength := byteOrder.Uint32(command.Body[i : i+4])
 
 		if uint64(rawValueLength) > uint64(maxInt) {
 			return nil, fmt.Errorf("Length of value %v overflows integer max length %v on this platform", rawValueLength, maxInt)


### PR DESCRIPTION
This CL uses io.ReadFull to make sure all requested bytes are read from
an io.Reader.
It's also using binary.ByteOrder.Uint64 directly instead of going the
round about way through (slow) reflection.

Fixes zeromq/gomq#67.
Fixes zeromq/gomq#61.