### PR TITLE
Problem: unsupported protocol passed to net package

### DIFF
--- a/gomq.go
+++ b/gomq.go
@@ -1,12 +1,19 @@
 package gomq
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/zeromq/gomq/zmtp"
 )
+
+type ErrBadProto string;
+
+func (e ErrBadProto) Error() string {
+	return fmt.Sprintf("Protocol '%s' not known to gomq", string(e));
+}
 
 var (
 	defaultRetry = 250 * time.Millisecond
@@ -61,6 +68,10 @@ type Client interface {
 // to connect to the endpoint and perform a ZMTP handshake.
 func ConnectClient(c Client, endpoint string) error {
 	parts := strings.Split(endpoint, "://")
+
+	if parts[0] != "tcp" {
+		return ErrBadProto(parts[0])
+	}
 
 Connect:
 	netConn, err := net.Dial(parts[0], parts[1])

--- a/socket_test.go
+++ b/socket_test.go
@@ -259,3 +259,11 @@ func TestDealerExtRouter(t *testing.T) {
 
 	dealer.Close()
 }
+
+func TestBadEndpointError(t *testing.T) {
+	client := NewClient(zmtp.NewSecurityNull())
+	err := client.Connect("ipc://@/not-yet-implemented")
+	if err == nil {
+		t.Error("ipc protocol MUST raise error")
+	}
+}


### PR DESCRIPTION
Solution: declare ErrBadProto error and make check explicit.

... the real problem statement should be 'I love zeromq and want to
became better at golang' ¯\_(ツ)_/¯

BTW: my initial intent was to make other tests to fail explicitly when using different transport than tcp, but this is above my current golang-fu.