### PR TITLE
Problem: gomq is not module compatible

### DIFF
--- a/zmtp/go.mod
+++ b/zmtp/go.mod
@@ -1,0 +1,3 @@
+module github.com/zeromq/gomq/zmtp
+
+go 1.12


### PR DESCRIPTION
... which brings some problems, especially with gopls and other linters does not work well

Solution: add go.mod to zmtp submodule - one must add it there and to the main package afterwards. This change should be backward compatible with older go releases ...