### PR TITLE
fix: replace uuid with identity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
         - 1.x
 
 before_install:
-        - git clone git://github.com/jedisct1/libsodium.git
+        - git clone git://github.com/jedisct1/libsodium.git --branch stable
         - ( cd libsodium; ./autogen.sh; ./configure; make check; sudo make install; sudo ldconfig )
         - git clone git://github.com/zeromq/libzmq.git
         - ( cd libzmq; ./autogen.sh; ./configure; make check; sudo make install; sudo ldconfig )

--- a/client.go
+++ b/client.go
@@ -11,8 +11,9 @@ type ClientSocket struct {
 // NewClient accepts a zmtp.SecurityMechanism and returns
 // a ClientSocket as a gomq.Client interface.
 func NewClient(mechanism zmtp.SecurityMechanism) Client {
+	uuid, _ := newUUID()
 	return &ClientSocket{
-		Socket: NewSocket(false, zmtp.ClientSocketType, nil, mechanism),
+		Socket: NewSocket(false, zmtp.ClientSocketType, []byte(uuid), mechanism),
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -11,9 +11,8 @@ type ClientSocket struct {
 // NewClient accepts a zmtp.SecurityMechanism and returns
 // a ClientSocket as a gomq.Client interface.
 func NewClient(mechanism zmtp.SecurityMechanism) Client {
-	uuid, _ := newUUID()
 	return &ClientSocket{
-		Socket: NewSocket(false, zmtp.ClientSocketType, []byte(uuid), mechanism),
+		Socket: NewSocket(false, zmtp.ClientSocketType, nil, mechanism),
 	}
 }
 

--- a/socket.go
+++ b/socket.go
@@ -45,7 +45,7 @@ func (s *Socket) AddConnection(conn *Connection) {
 	s.lock.Lock()
 	uuid, err := conn.zmtp.GetIdentity()
 	if err != nil {
-		panic(err)
+		uuid, _ = newUUID()
 	}
 
 	s.conns[uuid] = conn

--- a/socket.go
+++ b/socket.go
@@ -1,6 +1,7 @@
 package gomq
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -42,7 +43,7 @@ func NewSocket(asServer bool, sockType zmtp.SocketType, sockID zmtp.SocketIdenti
 // It is goroutine safe.
 func (s *Socket) AddConnection(conn *Connection) {
 	s.lock.Lock()
-	uuid, err := newUUID()
+	uuid, err := conn.zmtp.GetIdentity()
 	if err != nil {
 		panic(err)
 	}
@@ -58,14 +59,22 @@ func (s *Socket) AddConnection(conn *Connection) {
 // exist in map
 func (s *Socket) RemoveConnection(uuid string) {
 	s.lock.Lock()
+	defer s.lock.Unlock()
 	for k, v := range s.ids {
 		if v == uuid {
 			s.ids = append(s.ids[:k], s.ids[k+1:]...)
+			s.conns[uuid].net.Close()
+			delete(s.conns, uuid)
 		}
 	}
-	s.conns[uuid].net.Close()
-	delete(s.conns, uuid)
-	s.lock.Unlock()
+}
+
+// GetConnection returns the connection by identity
+func (s *Socket) GetConnection(uuid string) (*Connection, error) {
+	if conns, ok := s.conns[uuid]; ok {
+		return conns, nil
+	}
+	return nil, errors.New("conn not exist")
 }
 
 // RetryInterval returns the retry interval used

--- a/zmtp/protocol.go
+++ b/zmtp/protocol.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	majorVersion uint8 = 3
-	minorVersion uint8 = 0
+	minorVersion uint8 = 1
 )
 
 const (


### PR DESCRIPTION
We can use connection‘s identity to identify itself and why do we need to regenerate a uuid to identify it?