### PR TITLE
zmtp: try to downgrade the protocol to talk to a lower protocol peer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
         - ( cd czmq; ./autogen.sh; ./configure; make check; sudo make install; sudo ldconfig )
 
 install:
-        - go get github.com/zeromq/gomq/zmtp
-        - go get github.com/zeromq/gomq
+        - go get github.com/myzhan/gomq/zmtp
+        - go get github.com/myzhan/gomq
 script:
         - go test -v .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GoMQ [![Build Status](https://travis-ci.org/zeromq/gomq.svg?branch=master)](https://travis-ci.org/zeromq/gomq) [![Doc Status](https://godoc.org/github.com/zeromq/gomq?status.png)](https://godoc.org/github.com/zeromq/gomq)
+# GoMQ [![Build Status](https://travis-ci.org/myzhan/gomq.svg?branch=master)](https://travis-ci.org/myzhan/gomq) [![Doc Status](https://godoc.org/github.com/myzhan/gomq?status.png)](https://godoc.org/github.com/myzhan/gomq)
 
 ## Introduction
 A pure Go implementation of the [ZeroMQ Message Transport Protocol](http://rfc.zeromq.org/spec:37). **Danger Will Robinson, Danger!** This code is very young. There will be false starts, APIs will change and things will break. If you are looking to use ZeroMQ with Go in a production project, we suggest using [GoCZMQ](http://github.com/zeromq/goczmq), which depends on the [CZMQ](http://github.com/zeromq/czmq) C API. 
@@ -15,7 +15,7 @@ GoMQ will be a pure Go implementation of a subset of ZMTP, wrapped with a friend
 * The CURVE securty mechanism
 
 ## Contribution Guidelines
-GoMQ adheres to the [Collective Code Construction Contract](http://rfc.zeromq.org/spec:22). For details, see [CONTRIBUTING.md](https://github.com/zeromq/gomq/blob/master/CONTRIBUTING.md). We believe that building a community is an essential component of succesful open source software, and not just a side effect. [People before code!](http://hintjens.com/blog:95)
+GoMQ adheres to the [Collective Code Construction Contract](http://rfc.zeromq.org/spec:22). For details, see [CONTRIBUTING.md](https://github.com/myzhan/gomq/blob/master/CONTRIBUTING.md). We believe that building a community is an essential component of succesful open source software, and not just a side effect. [People before code!](http://hintjens.com/blog:95)
 
 ## Setting Up Your Development Environment
 While the end goal of GoMQ is a pure Go implementation of ZeroMQ with no dependencies on cgo, we currently require cgo for our test suite. The friction this creates in getting started is unfortunate but we feel it's the best way to test interoperability between our implemenation and the reference implementation of the protocol. Assuming that you already have a working Go development environment ( see: [The Go Programming Language: Getting Started](https://golang.org/doc/install) ) you will additionally need the following libraries:
@@ -90,7 +90,7 @@ You should now be ready to get started. Fork gomq, clone it, and make sure the t
 --- PASS: TestExternalServer (0.25s)
 	socket_test.go:94: client received: "WORLD"
 PASS
-ok		github.com/zeromq/gomq	0.255s
+ok		github.com/myzhan/gomq	0.255s
 ```
 
 Now you're ready. Remember: pull requests should always be simple solutions to minimal problems. If you're stuck, want to discuss ideas or just want to say hello, some of us are usually lurking in the #zeromq channel on the [gophers slack](https://blog.gopheracademy.com/gophers-slack-community/).

--- a/client.go
+++ b/client.go
@@ -1,6 +1,6 @@
 package gomq
 
-import "github.com/zeromq/gomq/zmtp"
+import "github.com/myzhan/gomq/zmtp"
 
 // ClientSocket is a ZMQ_CLIENT socket type.
 // See: http://rfc.zeromq.org/spec:41

--- a/dealer.go
+++ b/dealer.go
@@ -1,6 +1,6 @@
 package gomq
 
-import "github.com/zeromq/gomq/zmtp"
+import "github.com/myzhan/gomq/zmtp"
 
 // DealerSocket is a ZMQ_DEALER socket type.
 // See: https://rfc.zeromq.org/spec:28

--- a/gomq.go
+++ b/gomq.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 type ErrBadProto string

--- a/pull.go
+++ b/pull.go
@@ -3,7 +3,7 @@ package gomq
 import (
 	"net"
 
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 // PullSocket is a ZMQ_PULL socket type.

--- a/push.go
+++ b/push.go
@@ -3,7 +3,7 @@ package gomq
 import (
 	"net"
 
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 // PushSocket is a ZMQ_PUSH socket type.

--- a/server.go
+++ b/server.go
@@ -3,7 +3,7 @@ package gomq
 import (
 	"net"
 
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 // ServerSocket is a ZMQ_SERVER socket type.

--- a/socket.go
+++ b/socket.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 // Socket is the base GoMQ socket type. It should probably

--- a/socket_test.go
+++ b/socket_test.go
@@ -5,8 +5,8 @@ import (
 	"net"
 	"testing"
 
-	"github.com/zeromq/gomq/internal/test"
-	"github.com/zeromq/gomq/zmtp"
+	"github.com/myzhan/gomq/internal/test"
+	"github.com/myzhan/gomq/zmtp"
 )
 
 func TestNewClient(t *testing.T) {

--- a/zmtp/conn.go
+++ b/zmtp/conn.go
@@ -15,6 +15,7 @@ type Connection struct {
 	securityMechanism          SecurityMechanism
 	socket                     Socket
 	isPrepared                 bool
+	isDowngraded               bool
 	asServer, otherEndAsServer bool
 }
 
@@ -128,7 +129,11 @@ func (c *Connection) recvGreeting(asServer bool) error {
 	}
 
 	if greeting.Version != version {
-		return fmt.Errorf("Version %v.%v received does match expected version %v.%v", int(greeting.Version[0]), int(greeting.Version[1]), int(majorVersion), int(minorVersion))
+		if greeting.Version[0] == version[0] && greeting.Version[1] < version[1] {
+			c.isDowngraded = true
+		} else {
+			return fmt.Errorf("Version %v.%v received does match expected version %v.%v", int(greeting.Version[0]), int(greeting.Version[1]), int(majorVersion), int(minorVersion))
+		}
 	}
 
 	var otherMechanism = fromNullPaddedString(greeting.Mechanism[:])

--- a/zmtp/go.mod
+++ b/zmtp/go.mod
@@ -1,3 +1,3 @@
-module github.com/zeromq/gomq/zmtp
+module github.com/myzhan/gomq/zmtp
 
 go 1.12


### PR DESCRIPTION
After reading the "Version Negotiation" section of rfc23, I think we can try to work with a lower protocol peer in the future.

See also: https://rfc.zeromq.org/spec/23/